### PR TITLE
Add WhatsApp fallback for parked vehicles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ This is a simple Flask application that displays real-time data from a Tesla veh
 
 4. Open `http://localhost:8013` in your browser (the server listens on `0.0.0.0:8013`).
 5. On the configuration page (`/config`) you can set your APRS call sign, passcode and an optional comment to transmit position packets via an EU APRS-IS server. You may also enable an additional WX packet using a separate call sign. Temperatures are included in Celsius within the comment. Positions are sent at most every 30 seconds while driving and at least every 10 minutes even without changes. WX packets obey the same limits and are only transmitted when the outside temperature changes or after ten minutes without an update. The page also lets you adjust the Tesla API polling interval and disable the announcement text.
-6. You can also enter the driver's phone number and your Infobip API key here. SMS messages to the driver can be enabled or disabled and you may choose whether they are only allowed while driving or at any time. If you restrict SMS to driving mode, messages remain possible for ten minutes after parking and are then disabled.
+6. You can also enter the driver's phone number and your Infobip API key here. SMS messages to the driver can be enabled or disabled and you may choose whether they are only allowed while driving or at any time. If you restrict SMS to driving mode, they stop working as soon as the vehicle is parked and the message is immediately sent via WhatsApp instead.
 7. When sending an SMS the sender's name is requested as well. The entire message including the name must not exceed 160 characters.
 8. You can optionally provide a base URL for Infobip. If omitted, `https://api.infobip.com` is used. The field is also available on the `/config` page.
+9. To send WhatsApp messages when parked, enter your WhatsApp sender number, template name and language on the configuration page.
 
 All API calls are logged to `data/api.log` without storing request details. The log file uses rotation and will grow to at most 1&nbsp;MB.
 Vehicle state changes are written to `data/state.log`.

--- a/app.py
+++ b/app.py
@@ -1556,6 +1556,36 @@ def api_occupant():
     return jsonify({"present": occupant_present})
 
 
+def _send_whatsapp(phone, message, api_key, base_url, sender, template, lang):
+    """Send a WhatsApp template message via Infobip."""
+    if not base_url.startswith("http"):
+        base_url = "https://" + base_url
+    url = base_url.rstrip("/") + "/whatsapp/1/message/template"
+    resp = requests.post(
+        url,
+        json={
+            "messages": [
+                {
+                    "from": sender,
+                    "to": phone,
+                    "content": {
+                        "templateName": template,
+                        "templateData": {"body": {"placeholders": [message]}},
+                        "language": lang,
+                    },
+                }
+            ]
+        },
+        headers={
+            "Authorization": f"App {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        timeout=10,
+    )
+    return resp
+
+
 @app.route("/api/sms", methods=["POST"])
 def api_sms():
     """Send a short text message using the configured phone number."""
@@ -1565,17 +1595,16 @@ def api_sms():
     phone = cfg.get("phone_number")
     api_key = cfg.get("infobip_api_key")
     base_url = cfg.get("infobip_base_url", "https://api.infobip.com")
+    wa_from = cfg.get("whatsapp_from")
+    wa_template = cfg.get("whatsapp_template")
+    wa_lang = cfg.get("whatsapp_lang", "de")
     if not phone:
         return jsonify({"success": False, "error": "No phone number configured"}), 400
     if not api_key:
         return jsonify({"success": False, "error": "No API key configured"}), 400
     drive_only = cfg.get("sms_drive_only", True)
-    if drive_only and last_shift_state in (None, "P"):
-        grace = 0
-        if park_start_ms is not None:
-            grace = int(time.time() * 1000) - park_start_ms
-        if grace >= 600000 or park_start_ms is None:
-            return jsonify({"success": False, "error": "Vehicle is not driving"}), 400
+    parked = last_shift_state in (None, "P")
+    use_whatsapp = drive_only and parked
     data = request.get_json(silent=True) or {}
     message = data.get("message", "").strip()
     name = data.get("name", "").strip()
@@ -1588,10 +1617,26 @@ def api_sms():
     try:
         if not base_url.startswith("http"):
             base_url = "https://" + base_url
-        url = base_url.rstrip("/") + "/sms/2/text/advanced"
-        resp = requests.post(
-            url,
-            json={
+        if use_whatsapp and wa_from and wa_template:
+            url = base_url.rstrip("/") + "/whatsapp/1/message/template"
+            payload = {
+                "messages": [
+                    {
+                        "from": wa_from,
+                        "to": phone,
+                        "content": {
+                            "templateName": wa_template,
+                            "templateData": {"body": {"placeholders": [message]}},
+                            "language": wa_lang,
+                        },
+                    }
+                ]
+            }
+        else:
+            if drive_only and use_whatsapp and not (wa_from and wa_template):
+                return jsonify({"success": False, "error": "Vehicle is not driving"}), 400
+            url = base_url.rstrip("/") + "/sms/2/text/advanced"
+            payload = {
                 "messages": [
                     {
                         "destinations": [{"to": phone}],
@@ -1599,7 +1644,10 @@ def api_sms():
                         "text": message,
                     }
                 ]
-            },
+            }
+        resp = requests.post(
+            url,
+            json=payload,
             headers={
                 "Authorization": f"App {api_key}",
                 "Content-Type": "application/json",
@@ -1634,6 +1682,9 @@ def config_page():
         phone_number = request.form.get("phone_number", "").strip()
         infobip_api_key = request.form.get("infobip_api_key", "").strip()
         infobip_base_url = request.form.get("infobip_base_url", "").strip()
+        whatsapp_from = request.form.get("whatsapp_from", "").strip()
+        whatsapp_template = request.form.get("whatsapp_template", "").strip()
+        whatsapp_lang = request.form.get("whatsapp_lang", "").strip()
         sms_enabled = "sms_enabled" in request.form
         sms_drive_only = "sms_drive_only" in request.form
         api_interval = request.form.get("api_interval", "").strip()
@@ -1675,6 +1726,18 @@ def config_page():
             cfg["infobip_base_url"] = infobip_base_url
         elif "infobip_base_url" in cfg:
             cfg.pop("infobip_base_url")
+        if whatsapp_from:
+            cfg["whatsapp_from"] = whatsapp_from
+        elif "whatsapp_from" in cfg:
+            cfg.pop("whatsapp_from")
+        if whatsapp_template:
+            cfg["whatsapp_template"] = whatsapp_template
+        elif "whatsapp_template" in cfg:
+            cfg.pop("whatsapp_template")
+        if whatsapp_lang:
+            cfg["whatsapp_lang"] = whatsapp_lang
+        elif "whatsapp_lang" in cfg:
+            cfg.pop("whatsapp_lang")
         cfg["sms_enabled"] = sms_enabled
         cfg["sms_drive_only"] = sms_drive_only
         if api_interval.isdigit():

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -120,14 +120,14 @@ function updateSmsForm() {
     var hasNumber = cfg.phone_number && cfg.infobip_api_key && cfg.sms_enabled !== false;
     smsForm.toggle(!!hasNumber);
     var driveOnly = cfg.sms_drive_only !== false;
-    var parkedSince = parkStartTime ? Date.now() - parkStartTime : 0;
-    var allowWhileParked = parkedSince > 0 && parkedSince < 600000;
-    var enabled = hasNumber && (!driveOnly || (currentGear && currentGear !== 'P') || allowWhileParked);
+    var parked = !currentGear || currentGear === 'P';
+    var hasWa = cfg.whatsapp_from && cfg.whatsapp_template;
+    var enabled = hasNumber && (!driveOnly || !parked || hasWa);
     smsNameInput.prop('disabled', !enabled);
     smsInput.prop('disabled', !enabled);
     smsButton.prop('disabled', !enabled);
     if (!enabled) {
-        if (hasNumber && driveOnly && (!currentGear || currentGear === 'P')) {
+        if (hasNumber && driveOnly && parked && !hasWa) {
             smsStatus.text('Nachricht nur während der Fahrt erlaubt');
         } else {
             smsStatus.text('');
@@ -135,7 +135,11 @@ function updateSmsForm() {
         smsNameInput.val('');
         smsInput.val('');
     } else {
-        smsStatus.text('');
+        if (hasWa && driveOnly && parked) {
+            smsStatus.text('Sende via WhatsApp');
+        } else {
+            smsStatus.text('');
+        }
     }
 }
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -89,6 +89,24 @@
         </div>
         <div>
             <label>
+                WhatsApp Absender
+                <input type="text" name="whatsapp_from" value="{{ config.get('whatsapp_from','') }}">
+            </label>
+        </div>
+        <div>
+            <label>
+                WhatsApp Vorlage
+                <input type="text" name="whatsapp_template" value="{{ config.get('whatsapp_template','') }}">
+            </label>
+        </div>
+        <div>
+            <label>
+                WhatsApp Sprache
+                <input type="text" name="whatsapp_lang" value="{{ config.get('whatsapp_lang','de') }}">
+            </label>
+        </div>
+        <div>
+            <label>
                 <input type="checkbox" name="sms_enabled" value="1" {% if config.get('sms_enabled', True) %}checked{% endif %}>
                 SMS-Versand erlauben
             </label>


### PR DESCRIPTION
## Summary
- let parked messages send via WhatsApp
- expose WhatsApp parameters on the config page
- show hint in README about WhatsApp messages
- keep SMS form enabled and indicate WhatsApp usage
- switch immediately when gear is parked

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862fea3c61c8321b3f94da9ca5fd6e0